### PR TITLE
Updated to InfluxDB v0.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     - ./data/influxdb:/data
 
  influxdb:
-  image: tutum/influxdb:0.9
+  image: tutum/influxdb:0.13
   restart: always
   environment:
     - PRE_CREATE_DB=cadvisor


### PR DESCRIPTION
I had to change the InfluxDB version from 0.9 to 0.10 or higher (I have chosen the latest version 0.13), in order to circumvent a bug described in this InfluxDB pull request: https://github.com/tutumcloud/influxdb/pull/40.

In my case, this bug has lead to InfluxDB not accepting any connections on port 8083. This had lead to the repeated error message 
influxdb_1      | => Waiting for confirmation of InfluxDB service startup ...

We need to discuss, whether the update of InfluxDB has some side effects I do not know yet (in this repository, we find version-specific folders named influxdb_0.8_queries and influxdb_0.9_queries, so do we need another folder influxdb_0.13_queries folder?)...
